### PR TITLE
Fix HypEx poetry extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ timm = {version = ">=0.9.0", optional = true}
 opencv-python = {version = "<=4.8.0.74", optional = true}
 PyWavelets = {version = "*", optional = true}
 torchvision = {version = "*", optional = true}
+scikit-image = {version = "*", optional = true}
+efficientnet-pytorch = {version = "*", optional = true}
 
 # AFG
 featuretools = {version = ">=1.11.1", optional = true}
@@ -87,6 +89,7 @@ cffi = {version = "1.14.5", optional = true}
 
 # HypEx
 hypex = {version = "*", optional = true}
+faiss-cpu = {version = "*", optional = true}
 
 
 [tool.poetry.extras]
@@ -114,6 +117,7 @@ afg = [
 
 hypex = [
     "hypex",
+    "faiss-cpu",
 ]
 
 all = [
@@ -130,6 +134,7 @@ all = [
     "weasyprint",
     "featuretools",
     "hypex",
+    "faiss-cpu",
 ]
 
 


### PR DESCRIPTION
## Summary
- ensure extras for HypEx install required dependencies
- add missing optional dependencies for computer vision extras

## Testing
- `poetry check` *(fails: warnings but no errors)*
- `pytest -k nothing -s` *(fails: command not found)*